### PR TITLE
fix: disable cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { RepomdInfo, Mirror } from "./types/tetsudou";
 import { Document, Hash, MFile, Resources } from "./types/metalink";
 import { HTTPException } from "hono/http-exception";
 import xml from "xml-js";
-import { cache } from "hono/cache";
+// import { cache } from "hono/cache";
 import { selectMirrors } from "./utils/selection";
 import { postEvent } from "./utils/plausible";
 
@@ -32,10 +32,10 @@ app.get(
     c.executionCtx.waitUntil(postEvent(c.req));
     await next();
   },
-  cache({
-    cacheName: "tetsudou",
-    cacheControl: "max-age=300",
-  }),
+  // cache({
+  //   cacheName: "tetsudou",
+  //   cacheControl: "max-age=300",
+  // }),
   zValidator("query", metalinkParams),
   async (c) => {
     const { repo, arch } = c.req.valid("query");


### PR DESCRIPTION
To be fair, this was always a bit of a hack, but a workable one for when repos aren't being updated too often. However, as Terra has grown, so has the pace of updates.

For now, let's disable the cache. I'm thinking we could have subatomic upload the hash data to KV instead of pulling a file for an actual fix?