### PR TITLE
Add mirror.alebcay.com mirror to supported repos

### DIFF
--- a/repos/terra39.json
+++ b/repos/terra39.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra39",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra40-source.json
+++ b/repos/terra40-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra40-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra40.json
+++ b/repos/terra40.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra40",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra41-extras-source.json
+++ b/repos/terra41-extras-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra41-extras-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra41-extras.json
+++ b/repos/terra41-extras.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra41-extras",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra41-mesa-source.json
+++ b/repos/terra41-mesa-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra41-mesa-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra41-mesa.json
+++ b/repos/terra41-mesa.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra41-mesa",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra41-nvidia-source.json
+++ b/repos/terra41-nvidia-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra41-nvidia-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra41-nvidia.json
+++ b/repos/terra41-nvidia.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra41-nvidia",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra41-source.json
+++ b/repos/terra41-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra41-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra41.json
+++ b/repos/terra41.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra41",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra42-extras-source.json
+++ b/repos/terra42-extras-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra42-extras-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra42-extras.json
+++ b/repos/terra42-extras.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra42-extras",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra42-mesa-source.json
+++ b/repos/terra42-mesa-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra42-mesa-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra42-mesa.json
+++ b/repos/terra42-mesa.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra42-mesa",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra42-nvidia-source.json
+++ b/repos/terra42-nvidia-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra42-nvidia-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra42-nvidia.json
+++ b/repos/terra42-nvidia.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra42-nvidia",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra42-source.json
+++ b/repos/terra42-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra42-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terra42.json
+++ b/repos/terra42.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terra42",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrael10-source.json
+++ b/repos/terrael10-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrael10-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrael10.json
+++ b/repos/terrael10.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrael10",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrarawhide-extras-source.json
+++ b/repos/terrarawhide-extras-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrarawhide-extras-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrarawhide-extras.json
+++ b/repos/terrarawhide-extras.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrarawhide-extras",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrarawhide-mesa-source.json
+++ b/repos/terrarawhide-mesa-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrarawhide-mesa-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrarawhide-mesa.json
+++ b/repos/terrarawhide-mesa.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrarawhide-mesa",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrarawhide-nvidia-source.json
+++ b/repos/terrarawhide-nvidia-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrarawhide-nvidia-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrarawhide-nvidia.json
+++ b/repos/terrarawhide-nvidia.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrarawhide-nvidia",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrarawhide-source.json
+++ b/repos/terrarawhide-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrarawhide-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/terrarawhide.json
+++ b/repos/terrarawhide.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/terrarawhide",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/um40-source.json
+++ b/repos/um40-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/um40-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/um40.json
+++ b/repos/um40.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/um40",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/um41-source.json
+++ b/repos/um41-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/um41-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/um41.json
+++ b/repos/um41.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/um41",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/um42-source.json
+++ b/repos/um42-source.json
@@ -34,5 +34,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/um42-source",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]

--- a/repos/um42.json
+++ b/repos/um42.json
@@ -43,5 +43,14 @@
     "lat": 49.4542,
     "lon": 11.0775,
     "protocols": ["https"]
+  },
+  {
+    "url": "mirror.alebcay.com/files/fyralabs/um42",
+    "asn": 36352,
+    "continent": "NA",
+    "country": "US",
+    "lat": 34.0549,
+    "lon": -118.2426,
+    "protocols": ["https"]
   }
 ]


### PR DESCRIPTION
Hi there 👋 I'd like to offer a mirror for all repos in https://repos.fyralabs.com/ at https://mirror.alebcay.com/files/fyralabs/.
- Updated via `rclone sync` as often as every 5 minutes (subsequent sync will wait until ongoing sync is completed, if sync takes longer than 5 minutes)
  - Last sync time and mirror size/file count: https://mirror.alebcay.com/stats/fyralabs/
- This mirror should provide better coverage for western US (located in Los Angeles)

Please let me know if you have any questions/concerns. Thanks!