### PR TITLE
fix: remove cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import { RepomdInfo, Mirror } from "./types/tetsudou";
 import { Document, Hash, MFile, Resources } from "./types/metalink";
 import { HTTPException } from "hono/http-exception";
 import xml from "xml-js";
-import { cache } from "hono/cache";
 import { selectMirrors } from "./utils/selection";
 import { postEvent } from "./utils/plausible";
 import api from "./api";
@@ -30,10 +29,6 @@ app.get(
     c.executionCtx.waitUntil(postEvent(c.req));
     await next();
   },
-  cache({
-    cacheName: "tetsudou",
-    cacheControl: "max-age=300",
-  }),
   arktypeValidator("query", metalinkParams, (result, c) => {
     if (!result.success) {
       return c.json({ success: false, errors: result.errors.summary }, 400);


### PR DESCRIPTION
This was always supposed to be a temporary fix for the origin going down, but now that our worker doesn't have to fetch the origin every request, this isn't needed.

This could have caused two issues:
- For the cache period, the repomd could have drifted from what was alive.
- Users who got returned cached requests may have gotten mirrors based on someone else's location.

This is why we make issues when temporary fixes are made, because then we forget, and they don't become so temporary anymore.