### PR TITLE
feat: improve request repos.fyralabs.com reliability

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,10 +1,9 @@
 // Authenticated API for controlling and querying Tetsudou
 
 import { Hono } from "hono";
-import { HTTPException } from "hono/http-exception";
-import { RepomdInfo } from "./types/tetsudou";
 import { bearerAuth } from "hono/bearer-auth";
 import { env } from "cloudflare:workers";
+import { refreshRepo } from "./refresh";
 
 const api = new Hono<{ Bindings: Env }>();
 api.use(bearerAuth({ token: env.API_KEY }));
@@ -13,18 +12,7 @@ api.use(bearerAuth({ token: env.API_KEY }));
 api.post("/repos/:repo/refresh", async (c) => {
   const repo = c.req.param("repo");
 
-  const response = await fetch(
-    `https://repos.fyralabs.com/${repo}/repodata/tetsudou.json`,
-  );
-  if (!response.ok) {
-    throw new HTTPException(500, { message: "Failed to fetch metadata" });
-  }
-  const tetsudouMetadata = (await response.json()) as RepomdInfo;
-
-  await c.env.TETSUDOU.put(
-    `metadata/${repo}`,
-    JSON.stringify(tetsudouMetadata),
-  );
+  await refreshRepo(repo, c.env)
 
   return c.body(null, 204);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { type } from "arktype";
 import { RepomdInfo, Mirror } from "./types/tetsudou";
 import { Document, Hash, MFile, Resources } from "./types/metalink";
+import { refreshRepo } from "./refresh";
 import { HTTPException } from "hono/http-exception";
 import xml from "xml-js";
 import { selectMirrors } from "./utils/selection";
@@ -129,4 +130,35 @@ app.get(
   },
 );
 
-export default app;
+const scheduled = async (
+  _controller: ScheduledController,
+  env: Env,
+  _ctx: ExecutionContext,
+) => {
+  const mirrors = await env.TETSUDOU.get("mirrors");
+  if (mirrors === null) {
+    throw new Error("No mirrors found");
+  }
+
+  const mirrorList = (JSON.parse(mirrors) as Mirror[])
+
+  const repos = new Set<string>();
+  for (const mirror of mirrorList) {
+    for (const repo of mirror.repos) {
+      repos.add(repo);
+    }
+  }
+
+  for (const repo of repos) {
+    try {
+      await refreshRepo(repo, env);
+    } catch (error) {
+      console.log(`Failed to refresh ${repo}`, error);
+    }
+  }
+};
+
+export default {
+  fetch: app.fetch,
+  scheduled,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ const scheduled = async (
 ) => {
   const repos = (await env.TETSUDOU.list({
     prefix: "metadata/"
-  })).keys.map(key => key.name)
+  })).keys.map(key => key.name.replace("metadata/", ''))
 
   for (const repo of repos) {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,19 +135,9 @@ const scheduled = async (
   env: Env,
   _ctx: ExecutionContext,
 ) => {
-  const mirrors = await env.TETSUDOU.get("mirrors");
-  if (mirrors === null) {
-    throw new Error("No mirrors found");
-  }
-
-  const mirrorList = (JSON.parse(mirrors) as Mirror[])
-
-  const repos = new Set<string>();
-  for (const mirror of mirrorList) {
-    for (const repo of mirror.repos) {
-      repos.add(repo);
-    }
-  }
+  const repos = (await env.TETSUDOU.list({
+    prefix: "metadata/"
+  })).keys.map(key => key.name)
 
   for (const repo of repos) {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,7 @@ const scheduled = async (
     try {
       await refreshRepo(repo, env);
     } catch (error) {
-      console.log(`Failed to refresh ${repo}`, error);
+      console.error(`Failed to refresh ${repo}`, error);
     }
   }
 };

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -18,7 +18,8 @@ export const refreshRepo = async (
       }
       tetsudouMetadata = (await response.json()) as RepomdInfo;
     } catch (error) {
-      console.log(`error requesting ${repo}. attempt #${i}`)
+      console.log(`error requesting ${repo}. attempt #${i+1}`)
+      console.log(error)
     }
   }
 

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -20,8 +20,8 @@ export const refreshRepo = async (
       }
       tetsudouMetadata = (await response.json()) as RepomdInfo;
     } catch (error) {
-      console.log(`error requesting ${repo}. attempt #${i+1}`)
-      console.log(error)
+      console.error(`error requesting ${repo}. attempt #${i+1}`)
+      console.error(error)
       const delay = ATTEMPT_DELAY_BASE * ATTEMPT_DELAY_MULTIPLIER ** i
       await new Promise((resolve, _) => setTimeout(resolve, delay))
     }

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -2,6 +2,8 @@ import { RepomdInfo } from "./types/tetsudou";
 import { HTTPException } from "hono/http-exception";
 
 const RETRY_ATTEMPTS = 3;
+const ATTEMPT_DELAY_BASE = 1000;
+const ATTEMPT_DELAY_MULTIPLIER = 2;
 
 export const refreshRepo = async (
   repo: string,
@@ -20,6 +22,8 @@ export const refreshRepo = async (
     } catch (error) {
       console.log(`error requesting ${repo}. attempt #${i+1}`)
       console.log(error)
+      const delay = ATTEMPT_DELAY_BASE * ATTEMPT_DELAY_MULTIPLIER ** i
+      await new Promise((resolve, _) => setTimeout(resolve, delay))
     }
   }
 

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -1,0 +1,33 @@
+import { RepomdInfo } from "./types/tetsudou";
+import { HTTPException } from "hono/http-exception";
+
+const RETRY_ATTEMPTS = 3;
+
+export const refreshRepo = async (
+  repo: string,
+  env: Env,
+): Promise<void> => {
+  let tetsudouMetadata = undefined;
+  for (let i = 0; i < RETRY_ATTEMPTS; i++) {
+    try {
+      const response = await fetch(
+        `https://repos.fyralabs.com/${repo}/repodata/tetsudou.json`,
+      );
+      if (!response.ok) {
+        throw new HTTPException(500, { message: "Failed to fetch metadata" });
+      }
+      tetsudouMetadata = (await response.json()) as RepomdInfo;
+    } catch (error) {
+      console.log(`error requesting ${repo}. attempt #${i}`)
+    }
+  }
+
+  if (tetsudouMetadata == undefined) {
+    throw new HTTPException(500, { message: "Failed to fetch metadata" });
+  }
+
+  await env.TETSUDOU.put(
+    `metadata/${repo}`,
+    JSON.stringify(tetsudouMetadata),
+  );
+};

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -16,7 +16,13 @@ export const refreshRepo = async (
         `https://repos.fyralabs.com/${repo}/repodata/tetsudou.json`,
       );
       if (!response.ok) {
-        throw new HTTPException(500, { message: "Failed to fetch metadata" });
+        let response_body;
+        try {
+          response_body = await response.text()
+        } catch (error) {
+          response_body = String(error)
+        }
+        throw new Error("Failed to fetch metadata. " + response_body);
       }
       tetsudouMetadata = (await response.json()) as RepomdInfo;
     } catch (error) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,9 @@ compatibility_flags = [ "nodejs_compat" ]
 compatibility_date = "2024-09-23"
 account_id = "b5233d7eddf19b9902e2afab0a73ac11"
 
+[triggers]
+crons = [ "*/15 * * * *" ]
+
 [[kv_namespaces]]
 binding = "TETSUDOU"
 id = "7e26e8aeb0734e4fac90858a80929ac6"


### PR DESCRIPTION
Currently the refresh route is only ran by subatomic. if the request to https://repos.fyralabs.com/${repo}/repodata/tetsudou.json fails, the repo will be updated without tetsudou's metadata being updated. this will result in tetsudou serving out of date checksums and result in all mirrors being considered invalid by dnf.

This solves this in two ways.

1) repos requests are now reattempted up to 3 times so if its just a random failure it will immediately solve itself.
2) there is now a cron job so if repos comes back up tetsudou should eventually fix itself on its own.

possible concerns/questions:

1) how often should the cron run?
2) can a refresh cause issues if done at the wrong timing as subatomic doing something?
3) retry attempt count/delays?
4) cron being done in parallel (currently its sync just to not send a large blast at repos but repos might get so much traffic that this traffic doesnt matter)



for the record the issue of terra repos going down due to this issue is currently more common due to repos.fyralabs.com having intermittent issues, but even without this problem, not having retries would eventually cause a problem due to random request failures. 

an alternative solution would be to add something to subatomic to make sure that tetsudou updates first but no matter what we do there is a split state issue where the data cant be in sync 100% of the time unless we change the architecture of tetsudou. 